### PR TITLE
chore: updated node version to mirror carbon

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "rimraf": "^3.0.2"
   },
   "engines": {
-    "node": "12.x"
+    "node": ">=12.x"
   },
   "license": "Apache-2.0",
   "author": "James Dow",

--- a/packages/demo-site/package.json
+++ b/packages/demo-site/package.json
@@ -18,9 +18,6 @@
     "Demo",
     "Test"
   ],
-  "engines": {
-    "node": "12.x"
-  },
   "license": "Apache-2.0",
   "author": "James Dow",
   "repository": {

--- a/packages/token-server/package.json
+++ b/packages/token-server/package.json
@@ -17,9 +17,6 @@
     "Development",
     "Tokens"
   ],
-  "engines": {
-    "node": "12.x"
-  },
   "license": "Apache-2.0",
   "author": "James Dow",
   "repository": {

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -20,9 +20,6 @@
     "Utilities",
     "Functions"
   ],
-  "engines": {
-    "node": "12.x"
-  },
   "license": "Apache-2.0",
   "author": "James Dow",
   "repository": {


### PR DESCRIPTION
Updated engine to mirror carbon's node engine version so 12 or higher can be used.

#### Changelog

##### Changed

- updated engine node version

##### Removed

- removed engines on lower packages
