### PR TITLE
chore: updating togglesmall to toggle size="sm"

### DIFF
--- a/packages/web-extension/src/options/components/General/index.js
+++ b/packages/web-extension/src/options/components/General/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { settings } from 'carbon-components';
-import { Select, SelectItem, ToggleSmall } from 'carbon-components-react';
+import { Select, SelectItem, Toggle } from 'carbon-components-react';
 import { configuration } from '../';
 import { themes } from '@carbon/themes';
 
@@ -17,7 +17,8 @@ function General({
     <>
       <div className={`${prefix}--row`}>
         <div className={`${prefix}--col-sm-2`}>
-          <ToggleSmall
+          <Toggle
+            size="sm"
             labelText="Non-carbon pages"
             className={`${prefix}--options__non-carbon`}
             id="nonCarbon"
@@ -30,7 +31,8 @@ function General({
           />
         </div>
         <div className={`${prefix}--col-sm-2`}>
-          <ToggleSmall
+          <Toggle
+            size="sm"
             labelText="Experimental features"
             className={`${prefix}--options__experimental`}
             id="experimental"

--- a/packages/web-extension/src/popup/components/Grid/index.js
+++ b/packages/web-extension/src/popup/components/Grid/index.js
@@ -6,7 +6,7 @@ import {
   getStorage,
   gaConfigurationEvent,
 } from '@carbon/devtools-utilities';
-import { ToggleSmall } from 'carbon-components-react';
+import { Toggle } from 'carbon-components-react';
 import { Grid2xOptions } from './Grid2xOptions';
 import { GridMiniUnitOptions } from './GridMiniUnitOptions';
 
@@ -63,7 +63,8 @@ function Grid({ disabled }) {
             </h2>
           </div>
           <div className={`${prefix}--col-sm-2`}>
-            <ToggleSmall
+            <Toggle
+              size="sm"
               className={`${prefix}--popup-main__section-toggle`}
               disabled={disabled}
               id="toggle2xGrid"
@@ -87,7 +88,8 @@ function Grid({ disabled }) {
             </h2>
           </div>
           <div className={`${prefix}--col-sm-2`}>
-            <ToggleSmall
+            <Toggle
+              size="sm"
               className={`${prefix}--popup-main__section-toggle`}
               disabled={disabled}
               id="toggleMiniUnitGrid"

--- a/packages/web-extension/src/popup/components/Main/index.js
+++ b/packages/web-extension/src/popup/components/Main/index.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { settings } from 'carbon-components';
-import { Accordion, AccordionItem, ToggleSmall } from 'carbon-components-react';
+import { Accordion, AccordionItem, Toggle } from 'carbon-components-react';
 import { Inventory, Specs, Grid, Validation, ResizeBrowser } from '../';
 import {
   setStorage,
@@ -111,7 +111,8 @@ function Main({ initialMsg, panelControls }) {
             <div className={`${prefix}--row`}>
               <div className={`${prefix}--col-sm-2`}>{title}</div>
               <div className={`${prefix}--col-sm-2`}>
-                <ToggleSmall
+                <Toggle
+                  size="sm"
                   id={id}
                   className={`${prefix}--popup-main__toggle`}
                   toggled={globalToggleStates[id]}


### PR DESCRIPTION
Closes #70 

Updated dependencies based on deprecation warning we got from Carbon.

#### Changelog

##### Changed

- `<ToggleSmall />` to `<Toggle size="sm" />`
