### PR TITLE
fix: update cloud-cognitive to reflect new package name and prefix

### DIFF
--- a/packages/component-list/package.json
+++ b/packages/component-list/package.json
@@ -17,7 +17,7 @@
     "test": "yarn format && yarn lint"
   },
   "dependencies": {
-    "@carbon/ibm-cloud-cognitive": "^0.98.0",
+    "@carbon/ibm-products": "^1.2.4",
     "@carbon/ibm-security": "^1.31.0",
     "@carbon/ibmdotcom-react": "^1.27.0",
     "@carbon/ibmdotcom-web-components": "^1.12.0",

--- a/packages/component-list/src/libraries/cloud-cognitive.js
+++ b/packages/component-list/src/libraries/cloud-cognitive.js
@@ -1,4 +1,4 @@
-import * as _CloudCognitive from '@carbon/ibm-cloud-cognitive';
+import * as _CloudCognitive from '@carbon/ibm-products';
 import { _initStats } from '../helpers.js';
 
 const { _stats, success } = new _initStats();
@@ -27,7 +27,7 @@ cloudCognitive = Object.values(cloudCognitive).reduce(
 );
 
 cloudCognitive = {
-  name: 'IBM cloud cognitive',
+  name: 'Carbon for IBM Products',
   components: cloudCognitive,
   _stats,
 };

--- a/packages/web-extension/package.json
+++ b/packages/web-extension/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@carbon/colors": "^10.30.0",
     "@carbon/grid": "^10.33.0",
-    "@carbon/ibm-cloud-cognitive": "^0.98.0",
+    "@carbon/ibm-products": "^1.2.4",
     "@carbon/ibm-security": "^1.31.0",
     "@carbon/ibmdotcom-react": "^1.27.0",
     "@carbon/ibmdotcom-utilities": "^1.27.0",

--- a/packages/web-extension/src/globals/prefixSelectors.js
+++ b/packages/web-extension/src/globals/prefixSelectors.js
@@ -1,4 +1,4 @@
-import pkg from '@carbon/ibm-cloud-cognitive/es/global/js/package-settings';
+import pkg from '@carbon/ibm-products/es/global/js/package-settings';
 import dotcomSettings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings';
 import { getComponentNamespace as getSecurityPrefix } from '@carbon/ibm-security/es/globals/namespace';
 import carbonSettings from 'carbon-components/es/globals/js/settings';

--- a/packages/web-extension/src/options/components/Footer/index.js
+++ b/packages/web-extension/src/options/components/Footer/index.js
@@ -16,7 +16,7 @@ function getMajorVersion(dependency) {
   return getVersion(dependency).split('.')[0];
 }
 
-const CLOUD_COGNITIVE = '@carbon/ibm-cloud-cognitive';
+const CLOUD_COGNITIVE = '@carbon/ibm-products';
 
 const packages = [
   { name, version },

--- a/yarn.lock
+++ b/yarn.lock
@@ -987,10 +987,17 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.14.6", "@babel/runtime@^7.14.8", "@babel/runtime@^7.16.0", "@babel/runtime@^7.16.3", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.0", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.1", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.14.6", "@babel/runtime@^7.14.8", "@babel/runtime@^7.16.3", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.0", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.1", "@babel/runtime@^7.9.2":
   version "7.16.3"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.3.tgz#b86f0db02a04187a3c17caa77de69840165d42d5"
   integrity sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime@^7.16.5":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.7.tgz#03ff99f64106588c9c403c6ecb8c3bafbbdff1fa"
+  integrity sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -1066,14 +1073,14 @@
     "@carbon/import-once" "^10.6.0"
     "@carbon/layout" "^10.34.0"
 
-"@carbon/ibm-cloud-cognitive@^0.98.0":
-  version "0.98.0"
-  resolved "https://registry.yarnpkg.com/@carbon/ibm-cloud-cognitive/-/ibm-cloud-cognitive-0.98.0.tgz#1e04bc7b2921f848360e70bdef266522def55611"
-  integrity sha512-ZJnheBjRjZzZfpRoOZdJ4rQTDZ+2vXPWilfonXvoHbGc8TLWKLnlp6+PlYcd6DEgjM27I/mornDLoFfcYcC6NA==
+"@carbon/ibm-products@^1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@carbon/ibm-products/-/ibm-products-1.2.4.tgz#e98a35511bf44713885dbd6b2873030193217556"
+  integrity sha512-WUrnvlOeMT1WNfvAfOk43lKEyYK0VAnw+/FYLDEmZcBHJEgALnwqQTnDstMqsYXmV0cVrLUz/rGeRsHAVCcFbw==
   dependencies:
-    "@babel/runtime" "^7.16.0"
+    "@babel/runtime" "^7.16.5"
     "@carbon/telemetry" "^0.0.0-alpha.6"
-    react-resize-detector "^6.7.6"
+    react-resize-detector "^6.7.7"
 
 "@carbon/ibm-security@^1.31.0":
   version "1.46.0"
@@ -12702,14 +12709,13 @@ react-refresh@0.8.3:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.3.tgz#721d4657672d400c5e3c75d063c4a85fb2d5d68f"
   integrity sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg==
 
-react-resize-detector@^6.7.6:
-  version "6.7.6"
-  resolved "https://registry.yarnpkg.com/react-resize-detector/-/react-resize-detector-6.7.6.tgz#4416994e5ead7eba76606e3a248a1dfca49b67a3"
-  integrity sha512-/6RZlul1yePSoYJxWxmmgjO320moeLC/khrwpEVIL+D2EjLKhqOwzFv+H8laMbImVj7Zu4FlMa0oA7au3/ChjQ==
+react-resize-detector@^6.7.7:
+  version "6.7.8"
+  resolved "https://registry.yarnpkg.com/react-resize-detector/-/react-resize-detector-6.7.8.tgz#318c85d1335e50f99d4fb8eb9ec34e066db597d0"
+  integrity sha512-0FaEcUBAbn+pq3PT5a9hHRebUfuS1SRLGLpIw8LydU7zX429I6XJgKerKAMPsJH0qWAl6o5bVKNqFJqr6tGPYw==
   dependencies:
     "@types/resize-observer-browser" "^0.1.6"
-    lodash.debounce "^4.0.8"
-    lodash.throttle "^4.1.1"
+    lodash "^4.17.21"
     resize-observer-polyfill "^1.5.1"
 
 react-svg-core@^3.0.3:


### PR DESCRIPTION
Closes #198 

I have updated the Carbon for IBM Products package name which fixes the issue we currently have where our components no longer show up under the Component list.

##### Changed

- Changed package name for Carbon for IBM Products to reflect the current name/version.

#### Testing / Reviewing

Visit https://carbon-for-ibm-products.netlify.app/?path=/story/carbon-for-ibm-products-patterns-create-flows-createtearsheet--multi-step-tearsheet, and open the devtools (with a build from this branch) and you will now be able to see that the `CreateTearsheet` is now listed again.

For example, you can see that the extension now recognized the `ExpressiveCard` in this screenshot with our new package name and prefix.
![Screen Shot 2022-01-18 at 1 49 34 PM](https://user-images.githubusercontent.com/10215203/150003092-0f2d9dbe-b6ea-43c0-9dca-2a517f7ca2ce.png)

