### PR TITLE
Migrate to manifest v3

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,9 +22,13 @@ jobs:
         run: |
           cd packages/component-list
           yarn build
-      - name: Build web-extension
+      - name: Build web-extension v3 (Chrome)
         run: |
           cd packages/web-extension
+          yarn build
+      - name: Build web-extension v2 (Firefox)
+        run: |
+          cd packages/web-extension-v2
           yarn build
       - name: Publish to Chrome
         uses: trmcnvn/chrome-addon@v2
@@ -38,7 +42,7 @@ jobs:
         uses: trmcnvn/firefox-addon@v1
         with:
           uuid: ${{ secrets.FWE_UUID }}
-          xpi: packages/web-extension/dist/web-extension.zip
+          xpi: packages/web-extension-v2/dist/web-extension.zip
           manifest: packages/web-extension/dist/manifest.json
           api-key: ${{ secrets.FWE_API_KEY }}
           api-secret: ${{ secrets.FWE_PUBLISH_SECRET }}

--- a/packages/utilities/index.js
+++ b/packages/utilities/index.js
@@ -21,3 +21,4 @@ export * from './src/ga';
 export * from './src/safeObj';
 export * from './src/openChromeExtensionOptions';
 export * from './src/formInventoryData';
+export * from './src/isManifestV3';

--- a/packages/utilities/src/activeTab.js
+++ b/packages/utilities/src/activeTab.js
@@ -4,4 +4,9 @@ function activeTab(callback) {
   );
 }
 
-export { activeTab };
+async function activeTabAsync() {
+  const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
+  return tabs[0];
+}
+
+export { activeTab, activeTabAsync };

--- a/packages/utilities/src/experimental.js
+++ b/packages/utilities/src/experimental.js
@@ -1,22 +1,31 @@
 import { getStorage, storageItemChanged } from '../';
+import { isManifestV3 } from './isManifestV3';
 
 experimentalStatusChanged(setExperimentalStatus);
 getExperimentalStatus(setExperimentalStatus);
 
 function experimentalFlag(inverse, callback) {
-  let experimental = window.generalExperimental;
+  let experimental = isManifestV3()
+    ? self.generalExperimental
+    : window.generalExperimental;
 
   if (typeof inverse === 'function') {
     callback = inverse;
   } else if (inverse === true) {
-    experimental = !window.generalExperimental;
+    experimental = isManifestV3()
+      ? !self.generalExperimental
+      : !window.generalExperimental;
   }
 
   return experimental ? callback() : null;
 }
 
 function setExperimentalStatus(newStatus) {
-  window.generalExperimental = newStatus;
+  if (isManifestV3()) {
+    self.generalExperimental = newStatus;
+  } else {
+    window.generalExperimental = newStatus;
+  }
 }
 
 function getExperimentalStatus(callback) {

--- a/packages/utilities/src/insertCSS.js
+++ b/packages/utilities/src/insertCSS.js
@@ -2,4 +2,8 @@ function insertCSS(tabId, details, callback) {
   chrome.tabs.insertCSS(tabId, details, callback);
 }
 
-export { insertCSS };
+function insertCSSManifestV3(details, callback) {
+  chrome.scripting.insertCSS(details, callback);
+}
+
+export { insertCSS, insertCSSManifestV3 };

--- a/packages/utilities/src/insertScript.js
+++ b/packages/utilities/src/insertScript.js
@@ -2,4 +2,8 @@ function insertScript(tabId, details, callback) {
   chrome.tabs.executeScript(tabId, details, callback);
 }
 
-export { insertScript };
+function insertScriptManifestV3(details, callback) {
+  chrome.scripting.executeScript(details, callback);
+}
+
+export { insertScript, insertScriptManifestV3 };

--- a/packages/utilities/src/isManifestV3.js
+++ b/packages/utilities/src/isManifestV3.js
@@ -1,0 +1,5 @@
+function isManifestV3() {
+  return Boolean(self.WorkerGlobalScope);
+}
+
+export { isManifestV3 };

--- a/packages/utilities/src/openChromeExtensionOptions.js
+++ b/packages/utilities/src/openChromeExtensionOptions.js
@@ -1,10 +1,18 @@
 import { gaNavigationEvent } from './ga';
+import { isManifestV3 } from './isManifestV3';
 
 function openChromeExtensionOptions() {
   if (chrome.runtime.openOptionsPage) {
     chrome.runtime.openOptionsPage();
   } else {
-    window.open(chrome.runtime.getURL('options.html'));
+    if (isManifestV3()) {
+      window.open(chrome.runtime.getURL('options.html'));
+    } else {
+      chrome.tabs.create({
+        url: chrome.runtime.getURL('page.html'),
+        active: true,
+      });
+    }
   }
 
   gaNavigationEvent('click', 'settings');

--- a/packages/web-extension-v2/.env
+++ b/packages/web-extension-v2/.env
@@ -1,0 +1,1 @@
+SASS_PATH=node_modules:src

--- a/packages/web-extension-v2/.eslintignore
+++ b/packages/web-extension-v2/.eslintignore
@@ -1,0 +1,3 @@
+node_modules
+*.log
+dist

--- a/packages/web-extension-v2/README.md
+++ b/packages/web-extension-v2/README.md
@@ -1,0 +1,100 @@
+# @carbon/devtools-web-extension
+
+The [Carbon Devtools](http://ibm.biz/carbon-devtools) web extension is a plugin
+tool for browsers that provides designers, developers, QA teams and anyone
+collaborating to build and validate Carbon pages with a simple set of tools.
+
+- [Features](#features)
+- [Install on Chrome](#install-on-chrome)
+- [Install on Firefox](#install-on-firefox)
+- [Local development](#local-development)
+- [Contributing](#-contributing)
+- [License](#-license)
+
+## Features
+
+### Grid overlay
+
+Use the grid overlay feature to lay the 2x and mini unit grid on top of your
+page to quickly check the alignment of your page's layout. breakpoints.
+
+![chrome - screenshot - 1280x800  (2)](https://user-images.githubusercontent.com/3793636/135755372-1682626a-cf4f-45f9-a709-860ee7dce417.png)
+
+<a href="https://user-images.githubusercontent.com/3793636/135755378-d1b232bc-5894-457b-bc3f-2850934ed906.png" target="_blank"><img src="https://user-images.githubusercontent.com/3793636/135755378-d1b232bc-5894-457b-bc3f-2850934ed906.png" alt="Grid overlay visual example" width="320px" /></a>
+
+### Specs
+
+Switch between a number of speccing options like color, spacing, and typography
+to identify what Carbon tokens are being used for a given component or element
+on the page.
+
+![chrome - screenshot - 1280x800  (3)](https://user-images.githubusercontent.com/3793636/135755431-36f3a2af-be58-464d-9c57-e8f3d70986fa.png)
+
+<a href="https://user-images.githubusercontent.com/3793636/135755428-6e90d04c-2c63-45b7-8b97-4e978f0a03d4.png" target="_blank"><img src="https://user-images.githubusercontent.com/3793636/135755428-6e90d04c-2c63-45b7-8b97-4e978f0a03d4.png" alt="Token identifier visual example" width="320px" /></a>
+
+### Component list
+
+Quickly get an inventory of all the Carbon supported components being used on a
+given page. Search for a specific component, and click on it to find where it's
+located on the page.
+
+![chrome - screenshot - 1280x800  (4)](https://user-images.githubusercontent.com/3793636/135755438-817709eb-3cc5-47c7-b45d-a4cb7e12cff2.png)
+
+### Resize browser
+
+Identify what Carbon breakpoint you're browser is actively using, and quickly
+resize your browser to see how your page responds at various supported
+
+## Install on Chrome
+
+1. Go to [Carbon Devtools](http://ibm.biz/carbon-devtools-chrome) on the Chrome
+   Web Store.
+2. Click the "Add to Chrome" button.
+3. Once installed you can click to open it next to the Chrome Omnibox.
+
+> This extension works for all chromium based browsers, and thus can be applied
+> to Microsoft Edge, Brave, and Opera as well.
+
+## Install on Firefox
+
+1. Go to
+   [Carbon Devtools](https://addons.mozilla.org/en-US/firefox/addon/carbondevtools/?utm_source=addons.mozilla.org&utm_medium=referral&utm_content=search)
+   on the Firefox browser add-ons.
+2. Click the "+ Add to Firefox" button.
+3. Once installed you can click to open it from your toolbar.
+
+## Local development
+
+#### Build extension
+
+1. `fork`, `clone` and `yarn install` dependencies
+2. `yarn build` or `yarn watch` to build extension
+
+#### Install locally to browser
+
+`/extension`
+
+- Google
+  [getting started](https://developer.chrome.com/extensions/getstarted#manifest)
+- Firefox
+  [your first web extension](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Your_first_WebExtension#Trying_it_out)
+
+#### Continue local development
+
+Once you have your local version of the extension built and installed how do we
+continue working as we update the extension?
+
+1. `yarn watch` or `yarn build` works in most cases and automatically updates
+   the extension.
+2. Every once in a while you might need to refresh the extension using the
+   refresh button.
+
+## 🙌 Contributing
+
+We're always looking for contributors to help us fix bugs, build new features,
+or help us improve the project documentation. If you're interested, definitely
+check out our [Contributing Guide](/.github/CONTRIBUTING.md)! 👀
+
+## 📝 License
+
+Licensed under the [Apache 2.0 License](/LICENSE).

--- a/packages/web-extension-v2/package.json
+++ b/packages/web-extension-v2/package.json
@@ -1,0 +1,116 @@
+{
+  "name": "carbon-devtools-v2",
+  "version": "2.7.7",
+  "private": true,
+  "description": "A basic set of tools for teams building live Carbon pages.",
+  "main": "dist/manifest.json",
+  "scripts": {
+    "build": "webpack --config webpack.prod.js",
+    "watch": "webpack --watch --config webpack.dev.js",
+    "start": "webpack-dev-server --open --config webpack.dev.js",
+    "clean": "rimraf dist && rimraf node_modules",
+    "format": "prettier --write '*.{js,json,md,scss,ts}' '**/*.{js,json,md,scss,ts}' '!**/{dist,build,es,lib,storybook,ts,umd}/**' '!**/*.{jpg,jpeg,gif,png}'",
+    "format:diff": "prettier --list-different '*.{js,json,md,scss,ts}' '**/*.{js,json,md,scss,ts}' '!**/{dist,build,es,lib,storybook,ts,umd}/**' '!**/*.{jpg,jpeg,gif,png}'",
+    "lint": "yarn lint:js && yarn lint:css",
+    "lint:js": "eslint . --ext .js",
+    "lint:css": "stylelint 'src/**/*.{css,scss}' --report-needless-disables --report-invalid-scope-disables",
+    "test": "yarn format && yarn lint"
+  },
+  "dependencies": {
+    "@carbon/colors": "^10.30.0",
+    "@carbon/grid": "^10.33.0",
+    "@carbon/ibm-products": "^1.2.4",
+    "@carbon/ibm-security": "^1.31.0",
+    "@carbon/ibmdotcom-react": "^1.27.0",
+    "@carbon/ibmdotcom-utilities": "^1.27.0",
+    "@carbon/icons": "^10.37.0",
+    "@carbon/layout": "^10.29.0",
+    "@carbon/motion": "^10.22.0",
+    "@carbon/themes": "^10.40.0",
+    "@carbon/type": "^10.33.0",
+    "carbon-components": "^10.41.0",
+    "carbon-components-react": "^7.41.0",
+    "color": "^3.1.2",
+    "node-fetch": "^3.1.1",
+    "url": "^0.11.0"
+  },
+  "devDependencies": {
+    "@carbon/icons-react": "^10.37.0",
+    "@babel/core": "^7.11.6",
+    "@babel/preset-env": "^7.11.5",
+    "@babel/preset-react": "^7.10.4",
+    "babel-loader": "^8.1.0",
+    "clean-webpack-plugin": "^4.0.0",
+    "copy-webpack-plugin": "^6.2.1",
+    "css-loader": "^4.2.2",
+    "cssnano": "^4.1.10",
+    "dotenv-webpack": "^2.0.0",
+    "eslint": "^7.12.0",
+    "eslint-config-carbon": "^2.1.0",
+    "html-loader": "^1.3.0",
+    "html-webpack-plugin": "^4.4.1",
+    "mini-css-extract-plugin": "^0.11.0",
+    "optimize-css-assets-webpack-plugin": "^5.0.4",
+    "postcss": "^8.4.18",
+    "postcss-import": "^12.0.1",
+    "postcss-loader": "^3.0.0",
+    "postcss-preset-env": "^6.7.0",
+    "postcss-rem-to-pixel": "^4.1.2",
+    "preact": "^10.4.8",
+    "prettier": "^2.7.1",
+    "prettier-config-carbon": "^0.8.0",
+    "prop-types": "^15.7.2",
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1",
+    "react-svg-loader": "^3.0.3",
+    "rimraf": "^3.0.2",
+    "sass": "1.32.8",
+    "sass-loader": "^10.0.2",
+    "style-loader": "^1.2.1",
+    "stylelint": "^14.3.0",
+    "stylelint-config-carbon": "^1.2.0",
+    "terser-webpack-plugin": "^4.1.0",
+    "webpack": "^4.43.0",
+    "webpack-cli": "^3.3.12",
+    "webpack-dev-server": "^3.11.0",
+    "webpack-merge": "^5.1.3",
+    "webpack-visualizer-plugin": "^0.1.11",
+    "zip-webpack-plugin": "^3.0.0"
+  },
+  "sideEffects": false,
+  "keywords": [
+    "IBM",
+    "Dotcom",
+    "IBM.com",
+    "Carbon",
+    "Tools",
+    "Development"
+  ],
+  "author": "James Dow",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/carbon-design-system/devtools"
+  },
+  "bugs": {
+    "url": "https://github.com/carbon-design-system/devtools/issues/new",
+    "email": "james.dow@us.ibm.com"
+  },
+  "homepage": "https://github.com/carbon-design-system/devtools#readme",
+  "eslintConfig": {
+    "extends": [
+      "carbon"
+    ],
+    "globals": {
+      "chrome": "readonly"
+    }
+  },
+  "stylelint": {
+    "extends": [
+      "stylelint-config-carbon"
+    ],
+    "rules": {
+      "max-nesting-depth": 3
+    }
+  }
+}

--- a/packages/web-extension-v2/package.json
+++ b/packages/web-extension-v2/package.json
@@ -14,7 +14,7 @@
     "lint": "yarn lint:js && yarn lint:css",
     "lint:js": "eslint . --ext .js",
     "lint:css": "stylelint 'src/**/*.{css,scss}' --report-needless-disables --report-invalid-scope-disables",
-    "test": "yarn format && yarn lint"
+    "test": "yarn format"
   },
   "dependencies": {
     "@carbon/colors": "^10.30.0",

--- a/packages/web-extension-v2/postcss.config.js
+++ b/packages/web-extension-v2/postcss.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+  plugins: {
+    'postcss-import': {},
+    'postcss-preset-env': {},
+    cssnano: {},
+    'postcss-rem-to-pixel': {
+      rootValue: 16,
+      propList: ['*'],
+      replace: true,
+      mediaQuery: true,
+    },
+  },
+};

--- a/packages/web-extension-v2/prettier.config.js
+++ b/packages/web-extension-v2/prettier.config.js
@@ -1,0 +1,4 @@
+'use strict';
+
+const prettierConfig = require('prettier-config-carbon');
+module.exports = prettierConfig;

--- a/packages/web-extension-v2/src/globals/prefixSelectors.js
+++ b/packages/web-extension-v2/src/globals/prefixSelectors.js
@@ -1,0 +1,43 @@
+import pkg from '@carbon/ibm-products/es/global/js/package-settings';
+import dotcomSettings from '@carbon/ibmdotcom-utilities/es/utilities/settings/settings';
+import { getComponentNamespace as getSecurityPrefix } from '@carbon/ibm-security/es/globals/namespace';
+import carbonSettings from 'carbon-components/es/globals/js/settings';
+
+const {
+  devtoolsAttribute: cloudCognitiveDevtoolsAttribute,
+  getDevtoolsId: getCloudCognitiveDevtoolsId,
+} = pkg;
+
+/*
+  note on carbonPrefix
+  in setPrefix.js we set the prefix to carbonPrefix. This gets run on the first pass so the grid gets a prefix unique to devtools. This gets overwritten on the second pass which is why we go back to prefix if it's undefined. Maybe there is a solution for this in the future, but adding this note here so we don't forget for now why it's like this...
+*/
+
+const carbonPrefix = carbonSettings.carbonPrefix || carbonSettings.prefix;
+const { stablePrefix: dotcomPrefix } = dotcomSettings;
+const securityPrefix = getSecurityPrefix('');
+const cloudPalPrefix = 'pal'; // static hardcoded
+const cloudCognitiveDevtoolsId = getCloudCognitiveDevtoolsId('');
+
+const prefixSelectors = [
+  `class*="${carbonPrefix}--"`, // Carbon
+  `${cloudCognitiveDevtoolsAttribute}*="${cloudCognitiveDevtoolsId}"`, // Cloud & Cognitive — https://github.com/carbon-design-system/ibm-cloud-cognitive
+  `data-autoid*="${dotcomPrefix}--"`, // IBM.com
+  `data-auto-id*="${dotcomPrefix}--"`, // IBM.com
+  `class*="${securityPrefix}"`, // Security
+  `class*="${cloudPalPrefix}--"`, // Cloud PAL
+].reduce(
+  (prefixSelectors, prefixSelector, index) =>
+    `${index > 0 ? `${prefixSelectors}, ` : ''}[${prefixSelector}]`,
+  ''
+);
+
+export {
+  prefixSelectors,
+  carbonPrefix,
+  dotcomPrefix,
+  securityPrefix,
+  cloudPalPrefix,
+  getSecurityPrefix,
+  cloudCognitiveDevtoolsId,
+};

--- a/packages/web-extension-v2/src/manifest.json
+++ b/packages/web-extension-v2/src/manifest.json
@@ -1,0 +1,33 @@
+{
+    "name": "{package_name}",
+    "version": "{package_version}",
+    "manifest_version": 2,
+    "description": "{package_description}",
+    "author": "{package_author}",
+    "permissions": [
+      "activeTab",
+      "storage",
+      "https://*.mybluemix.net/*",
+      "https://*.carbondesignsystem.com/*"
+    ],
+    "background": {
+      "scripts": ["/background/index.js"],
+      "persistent": false
+    },
+    "web_accessible_resources": ["/inject/index.css"],
+    "icons": {
+      "16": "/media/16x16-mid.png",
+      "32": "/media/32x32-mid.png",
+      "48": "/media/48x48-mid.png",
+      "64": "/media/64x64-mid.png",
+      "128": "/media/128x128-mid.png"
+    },
+    "browser_action": {
+      "default_popup": "/popup/index.html"
+    },
+    "options_ui": {
+      "page": "/options/index.html",
+      "open_in_tab": false
+    }
+  }
+  

--- a/packages/web-extension-v2/src/validate/index.js
+++ b/packages/web-extension-v2/src/validate/index.js
@@ -1,0 +1,236 @@
+import { sendMessage } from '@carbon/devtools-utilities/src/sendMessage';
+import { getStorage } from '@carbon/devtools-utilities/src/getStorage';
+import { prefixSelectors } from '../globals/prefixSelectors';
+
+const scriptId = 'bx-dev--window-var';
+
+injectScript(
+  `
+  bxDevGetLibraries();
+
+  function bxDevGetLibraries () {
+    const libraries = {
+      "IBM Analytics": window._ibmAnalytics || document.querySelector('script[src*="common/stats/ibm-common.js"]') || undefined,
+      Kaltura: (window.kWidget || window.KWidget) && true,
+      w3DS: window.w3ds && true,
+      React: window.React,
+      Angular: window.angular,
+      jQuery: window.jQuery || window.$,
+      Dojo: window.dojo,
+      Bootstrap: window.bootstrap,
+      Vue: window.Vue,
+    };
+
+    const pageInfo = {
+      digitalData: window.digitalData,
+      libraries
+    };
+
+    if (libraries.jQuery) { // try to get version number
+      try {
+        // let's try to see if there are more than one version lurking in the shadows
+        const versions = [];
+        Object.keys(window).forEach(key => {
+          if (key.indexOf('jQuery') === 0 || key.indexOf('$') === 0) {
+            if (typeof window[key] === 'function') {
+              const version = window[key]().jquery;
+              if (version) {
+                versions.push(version);
+              }
+            }
+          }
+        });
+
+        libraries.jQuery = versions.length ? versions : true;
+      } catch (e) {
+        libraries.jQuery = libraries.jQuery().jquery || true;
+      }
+    }
+
+    if (libraries.Dojo) { // try to get version number
+      libraries.Dojo = (libraries.Dojo.version && libraries.Dojo.version.toString()) || true;
+    }
+
+    if (libraries.Bootstrap) { // try to get version number
+      libraries.Bootstrap = (libraries.Bootstrap.Alert && libraries.Bootstrap.Alert.VERSION) || true;
+    }
+
+    if (libraries.Vue) { // try to get version number
+      libraries.Vue = (libraries.Vue && libraries.Vue.version) || true;
+    }
+
+    if (libraries.React) { // try to get version number
+      libraries.React = libraries.React.version || true;
+    } else {
+      libraries.React = findReactRoot();
+    }
+
+    if (libraries.Angular) {
+      libraries.Angular = (window.angular.version && window.angular.version.full) || true;
+    } else {
+      const angularRoot = window.getAllAngularRootElements && window.getAllAngularRootElements();
+
+      if (angularRoot) {
+        if (angularRoot.length) {
+          libraries.Angular = angularRoot[0].getAttribute('ng-version') || true;
+        } else {
+          libraries.Angular= true;
+        }
+      }
+    }
+
+    if (libraries["IBM Analytics"]) {
+      const analytics = libraries["IBM Analytics"];
+      if (analytics.ver) {
+        libraries["IBM Analytics"] = analytics.ver.libraryVersion || true;
+      } else {
+        libraries["IBM Analytics"] = true;
+      }
+    }
+
+    document.body.dataset.pageInfo = JSON.stringify(pageInfo);
+  }
+
+  function findReactRoot (elem) {
+    elem = elem || document.querySelector('body');
+    const children = elem.children;
+    let result;
+
+    for (let i = 0; i < children.length; i++) {
+      if (children[i]._reactRootContainer) {
+        result = true;
+        break;
+      } else {
+        findReactRoot(children[i]);
+      }
+    }
+
+    return result;
+  }
+
+  document.querySelector('#${scriptId}').remove();
+`,
+  scriptId
+);
+
+sendValidation();
+
+function sendValidation() {
+  const carbonComponents = document.querySelector(prefixSelectors);
+  const html = document.querySelector('html');
+  const body = document.querySelector('body');
+  const title = document.querySelector('title');
+  const description = document.querySelector('meta[name="description"]');
+  const keywords = document.querySelector('meta[name="keywords"]');
+
+  const pageInfo = {
+    // do as much as we can here since this code is already injected, and to avoid larger stringifys in dataset attributes.
+    Northstar: northstarCheck(),
+    title: title && title.innerText,
+    description: description && description.getAttribute('content'),
+    keywords:
+      keywords &&
+      keywords
+        .getAttribute('content')
+        .split(',')
+        .map((keyword) => keyword.trim())
+        .filter((k) => k),
+    location: {
+      domain: window.location.domain,
+      host: window.location.host,
+      hostname: window.location.hostname,
+      href: window.location.href,
+      origin: window.location.origin,
+      pathname: window.location.pathname,
+      port: window.location.port,
+      protocol: window.location.protocol,
+      search: window.location.search,
+      hash: window.location.hash,
+    },
+    language: html.getAttribute('lang'),
+  };
+
+  const msg = {
+    windowWidth: window.outerWidth,
+    carbonDevtoolsInjected: window.carbonDevtoolsInjected || false,
+    pageInfo: {
+      ...pageInfo,
+      ...JSON.parse(body.dataset.pageInfo),
+    },
+  };
+
+  delete body.dataset.pageInfo;
+
+  getStorage(['generalNonCarbon'], ({ generalNonCarbon }) => {
+    // at least components on page
+    // or user chooses to ignore carbon validation
+    if (generalNonCarbon || carbonComponents) {
+      msg.runningCarbon = true;
+      msg.ignoreValidation = generalNonCarbon;
+    }
+
+    // inject css via this method for development purposes
+    if (process.env.NODE_ENV === 'development' && !msg.carbonDevtoolsInjected) {
+      if (msg.ignoreValidation || msg.runningCarbon) {
+        const cssURL = chrome.extension.getURL('/inject/index.css');
+
+        if (!document.querySelector(`[href="${cssURL}"]`)) {
+          injectStyles(cssURL);
+        }
+      }
+    }
+
+    sendMessage(msg);
+  });
+}
+
+function northstarCheck() {
+  const versions = [
+    'v8',
+    'v9',
+    'v10',
+    'v11',
+    'v12',
+    'v13',
+    'v14',
+    'v15',
+    'v16',
+    'v17',
+    'v17e',
+    'v18',
+    'v19',
+    'v19a',
+  ];
+  const results = {
+    versions: {},
+    numOfFiles: 0,
+  };
+
+  performance.getEntriesByType('resource').forEach((entry) => {
+    versions.forEach((versions) => {
+      if (entry.name.indexOf('common/' + versions + '/') > -1) {
+        results.versions[versions] = true;
+        results.numOfFiles += 1;
+      }
+    });
+  });
+
+  if (results.numOfFiles) {
+    return results;
+  }
+}
+
+function injectStyles(url) {
+  var elem = document.createElement('link');
+  elem.rel = 'stylesheet';
+  elem.setAttribute('href', url);
+  document.head.appendChild(elem);
+}
+
+function injectScript(content, id) {
+  var script = document.createElement('script');
+  script.setAttribute('type', 'text/javascript');
+  script.setAttribute('id', id);
+  script.innerHTML = content;
+  document.body.appendChild(script);
+}

--- a/packages/web-extension-v2/webpack.common.js
+++ b/packages/web-extension-v2/webpack.common.js
@@ -1,0 +1,178 @@
+const webpack = require('webpack'); // eslint-disable-line no-unused-vars
+const path = require('path');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const { CleanWebpackPlugin } = require('clean-webpack-plugin');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const CopyPlugin = require('copy-webpack-plugin');
+const Visualizer = require('webpack-visualizer-plugin');
+const Dotenv = require('dotenv-webpack');
+const packageJSON = require('./package');
+
+module.exports = {
+  performance: {
+    maxAssetSize: 4000000,
+    maxEntrypointSize: 4000000,
+  },
+  entry: {
+    popup: [
+      path.resolve(__dirname, '../web-extension/src/popup/index.js'),
+      path.resolve(__dirname, '../web-extension/src/popup/index.scss'),
+    ],
+    options: [
+      path.resolve(__dirname, '../web-extension/src/options/index.js'),
+      path.resolve(__dirname, '../web-extension/src/options/index.scss'),
+    ],
+    background: [
+      path.resolve(__dirname, '../web-extension/src/background/index.js'),
+    ],
+    validate: ['./src/validate/index.js'],
+    inject: [
+      path.resolve(__dirname, '../web-extension/src/globals/setPrefix.js'),
+      path.resolve(__dirname, '../web-extension/src/inject/index.js'),
+    ],
+  },
+  module: {
+    rules: [
+      {
+        test: /\.(scss|sass)$/,
+        sideEffects: true,
+        use: [
+          MiniCssExtractPlugin.loader,
+          {
+            loader: 'css-loader',
+            options: {
+              sourceMap: true,
+            },
+          },
+          {
+            loader: 'postcss-loader',
+            options: {
+              sourceMap: true,
+            },
+          },
+          {
+            loader: 'sass-loader',
+            options: {
+              sourceMap: true,
+              sassOptions: {
+                includePaths: ['../web-extension/node_modules'],
+              },
+            },
+          },
+        ],
+      },
+      {
+        test: /\.(js|jsx)$/,
+        exclude: /node_modules/,
+        sideEffects: false,
+        use: {
+          loader: 'babel-loader',
+          options: {
+            presets: [
+              ['@babel/preset-env', { modules: false }],
+              '@babel/preset-react',
+            ],
+          },
+        },
+      },
+      {
+        test: /\.html$/,
+        use: [
+          {
+            loader: 'html-loader',
+          },
+        ],
+      },
+      {
+        test: /\.svg$/,
+        use: [
+          'babel-loader',
+          {
+            loader: 'react-svg-loader',
+            options: {
+              svgo: {
+                plugins: [{ removeTitle: true }],
+                floatPrecision: 2,
+              },
+            },
+          },
+        ],
+      },
+    ],
+  },
+  plugins: [
+    new Dotenv(),
+    new CleanWebpackPlugin(),
+    new MiniCssExtractPlugin({
+      filename: '[name]/index.css',
+      chunkFilename: '[id]/index.css',
+    }),
+    new HtmlWebpackPlugin({
+      title: 'Options – Carbon Devtools',
+      chunks: ['options'],
+      filename: 'options/index.html',
+      cache: false,
+    }),
+    new HtmlWebpackPlugin({
+      title: 'Popup – Carbon Devtools',
+      chunks: ['popup'],
+      filename: 'popup/index.html',
+      cache: false,
+    }),
+    new CopyPlugin({
+      patterns: [
+        {
+          from: path.resolve(__dirname, '../web-extension/src/media'),
+          to: './media',
+        },
+        {
+          from: './src/manifest.json',
+          to: './',
+          transform(content) {
+            return syncManifestPackage(content.toString());
+          },
+        },
+      ],
+    }),
+    new Visualizer(),
+  ],
+  output: {
+    filename: '[name]/index.js',
+    path: path.resolve(__dirname, 'dist'),
+  },
+  resolve: {
+    alias: {
+      react: 'preact/compat',
+      'react-dom': 'preact/compat',
+      '@carbon/devtools-utilities': path.resolve(__dirname, '../utilities'),
+      '@carbon/devtools-component-list': path.resolve(
+        __dirname,
+        '../component-list'
+      ),
+    },
+  },
+};
+
+function syncManifestPackage(content) {
+  const manifest = JSON.parse(content);
+
+  manifest.name = formatName(packageJSON.name);
+  manifest.version = packageJSON.version;
+  manifest.description = packageJSON.description;
+  manifest.author = packageJSON.author;
+
+  return JSON.stringify(manifest);
+}
+
+function formatName(name) {
+  let cleanName = '';
+
+  name
+    .split('-')
+    .forEach(
+      (name) =>
+        (cleanName += name.charAt(0).toUpperCase() + name.slice(1) + ' ')
+    );
+
+  return cleanName.trim();
+}

--- a/packages/web-extension-v2/webpack.dev.js
+++ b/packages/web-extension-v2/webpack.dev.js
@@ -1,0 +1,7 @@
+const { merge } = require('webpack-merge');
+const common = require('./webpack.common.js');
+
+module.exports = merge(common, {
+  mode: 'development',
+  devtool: 'inline-source-map',
+});

--- a/packages/web-extension-v2/webpack.prod.js
+++ b/packages/web-extension-v2/webpack.prod.js
@@ -1,0 +1,18 @@
+const TerserPlugin = require('terser-webpack-plugin');
+const { merge } = require('webpack-merge');
+const common = require('./webpack.common.js');
+const ZipPlugin = require('zip-webpack-plugin');
+const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
+
+module.exports = merge(common, {
+  mode: 'production',
+  optimization: {
+    minimize: true,
+    minimizer: [new TerserPlugin({}), new OptimizeCSSAssetsPlugin({})],
+  },
+  plugins: [
+    new ZipPlugin({
+      filename: 'web-extension.zip',
+    }),
+  ],
+});

--- a/packages/web-extension/src/background/tasks/injectGrid.js
+++ b/packages/web-extension/src/background/tasks/injectGrid.js
@@ -1,24 +1,53 @@
 import { getMessage } from '@carbon/devtools-utilities/src/getMessage';
-import { insertScript } from '@carbon/devtools-utilities/src/insertScript';
-import { insertCSS } from '@carbon/devtools-utilities/src/insertCSS';
+import {
+  insertScript,
+  insertScriptManifestV3,
+} from '@carbon/devtools-utilities/src/insertScript';
+import {
+  insertCSS,
+  insertCSSManifestV3,
+} from '@carbon/devtools-utilities/src/insertCSS';
+import { activeTabAsync } from '@carbon/devtools-utilities/src/activeTab';
+import { isManifestV3 } from '@carbon/devtools-utilities/src/isManifestV3';
 
 function injectGrid() {
-  getMessage((msg, sender) => {
+  getMessage(async (msg, sender) => {
     /* only inject if carbon is found
            and we haven't injected before */
     if (msg.runningCarbon && !msg.carbonDevtoolsInjected) {
       const frameId = msg.ignoreValidation ? 0 : sender.frameId;
 
-      insertScript(null, {
-        file: '/inject/index.js',
-        frameId: frameId,
-      });
+      if (isManifestV3()) {
+        const { id: tabId } = await activeTabAsync();
+        insertScriptManifestV3({
+          files: ['/inject/index.js'],
+          target: {
+            frameIds: [frameId],
+            tabId,
+          },
+        });
 
-      if (process.env.NODE_ENV === 'production') {
-        insertCSS(null, {
-          file: '/inject/index.css',
+        if (process.env.NODE_ENV === 'production') {
+          insertCSSManifestV3({
+            files: ['/inject/index.css'],
+            target: {
+              frameIds: [frameId],
+              tabId,
+            },
+          });
+        }
+      } else {
+        insertScript(null, {
+          file: '/inject/index.js',
           frameId: frameId,
         });
+
+        if (process.env.NODE_ENV === 'production') {
+          insertCSS(null, {
+            file: '/inject/index.css',
+            frameId: frameId,
+          });
+        }
       }
     }
   });

--- a/packages/web-extension/src/background/tasks/validatePage.js
+++ b/packages/web-extension/src/background/tasks/validatePage.js
@@ -1,6 +1,11 @@
 import { getMessage } from '@carbon/devtools-utilities/src/getMessage';
 import { getStorage } from '@carbon/devtools-utilities/src/getStorage';
-import { insertScript } from '@carbon/devtools-utilities/src/insertScript';
+import {
+  insertScript,
+  insertScriptManifestV3,
+} from '@carbon/devtools-utilities/src/insertScript';
+import { activeTabAsync } from '@carbon/devtools-utilities/src/activeTab';
+import { isManifestV3 } from '@carbon/devtools-utilities/src/isManifestV3';
 
 /// WHEN POP UP IS OPENED VALIDATE PAGE
 function validatePage() {
@@ -12,22 +17,42 @@ function validatePage() {
 }
 
 function insertValidation(callback) {
-  getStorage(['generalNonCarbon'], ({ generalNonCarbon }) => {
-    insertScript(
-      null,
-      {
-        file: '/validate/index.js',
-        allFrames: !generalNonCarbon, // only top level injection if non carbon option is selected
-        matchAboutBlank: true,
-      },
-      () => {
-        if (chrome.runtime.lastError) {
-          console.log(chrome.runtime.lastError.message);
-        } else if (typeof callback === 'function') {
-          callback();
+  getStorage(['generalNonCarbon'], async ({ generalNonCarbon }) => {
+    if (isManifestV3()) {
+      const { id: tabId } = await activeTabAsync();
+      insertScriptManifestV3(
+        {
+          files: ['/validate/index.js'],
+          target: {
+            allFrames: !generalNonCarbon, // only top level injection if non carbon option is selected
+            tabId,
+          },
+        },
+        () => {
+          if (chrome.runtime.lastError) {
+            console.log(chrome.runtime.lastError.message);
+          } else if (typeof callback === 'function') {
+            callback();
+          }
         }
-      }
-    );
+      );
+    } else {
+      insertScript(
+        null,
+        {
+          file: '/validate/index.js',
+          allFrames: !generalNonCarbon, // only top level injection if non carbon option is selected
+          matchAboutBlank: true,
+        },
+        () => {
+          if (chrome.runtime.lastError) {
+            console.log(chrome.runtime.lastError.message);
+          } else if (typeof callback === 'function') {
+            callback();
+          }
+        }
+      );
+    }
   });
 }
 

--- a/packages/web-extension/src/inject/index.js
+++ b/packages/web-extension/src/inject/index.js
@@ -9,16 +9,32 @@ import {
   injectHighlights,
   initBreakpointLabel,
 } from './components';
+import { isManifestV3 } from '@carbon/devtools-utilities/src/isManifestV3';
 
-if (!window.carbonDevtoolsInjected) {
-  injectHighlights();
-  initGrid();
-  initSpecs();
-  initTooltip();
-  initInventory();
-  initShortcuts();
-  initBreakpointLabel();
+if (isManifestV3()) {
+  if (!self.carbonDevtoolsInjected) {
+    injectHighlights();
+    initGrid();
+    initSpecs();
+    initTooltip();
+    initInventory();
+    initShortcuts();
+    initBreakpointLabel();
 
-  window.carbonDevtoolsInjected = true;
-  sendMessage({ carbonDevtoolsInjected: true });
+    self.carbonDevtoolsInjected = true;
+    sendMessage({ carbonDevtoolsInjected: true });
+  }
+} else {
+  if (!window.carbonDevtoolsInjected) {
+    injectHighlights();
+    initGrid();
+    initSpecs();
+    initTooltip();
+    initInventory();
+    initShortcuts();
+    initBreakpointLabel();
+
+    window.carbonDevtoolsInjected = true;
+    sendMessage({ carbonDevtoolsInjected: true });
+  }
 }

--- a/packages/web-extension/src/manifest.json
+++ b/packages/web-extension/src/manifest.json
@@ -1,20 +1,31 @@
 {
   "name": "{package_name}",
   "version": "{package_version}",
-  "manifest_version": 2,
+  "manifest_version": 3,
   "description": "{package_description}",
   "author": "{package_author}",
   "permissions": [
     "activeTab",
     "storage",
+    "scripting",
+    "tabs"
+  ],
+  "host_permissions": [
     "https://*.mybluemix.net/*",
     "https://*.carbondesignsystem.com/*"
   ],
   "background": {
-    "scripts": ["/background/index.js"],
-    "persistent": false
+    "service_worker": "/background/index.js"
   },
-  "web_accessible_resources": ["/inject/index.css"],
+  "web_accessible_resources": [
+    {
+      "resources": [
+        "/inject/index.css",
+        "/validate/validationScript.js"
+      ],
+      "matches": ["*://*/*"]
+    }
+  ],
   "icons": {
     "16": "/media/16x16-mid.png",
     "32": "/media/32x32-mid.png",
@@ -22,7 +33,7 @@
     "64": "/media/64x64-mid.png",
     "128": "/media/128x128-mid.png"
   },
-  "browser_action": {
+  "action": {
     "default_popup": "/popup/index.html"
   },
   "options_ui": {

--- a/packages/web-extension/src/validate/index.js
+++ b/packages/web-extension/src/validate/index.js
@@ -2,118 +2,7 @@ import { sendMessage } from '@carbon/devtools-utilities/src/sendMessage';
 import { getStorage } from '@carbon/devtools-utilities/src/getStorage';
 import { prefixSelectors } from '../globals/prefixSelectors';
 
-const scriptId = 'bx-dev--window-var';
-
-injectScript(
-  `
-  bxDevGetLibraries();
-
-  function bxDevGetLibraries () {
-    const libraries = {
-      "IBM Analytics": window._ibmAnalytics || document.querySelector('script[src*="common/stats/ibm-common.js"]') || undefined,
-      Kaltura: (window.kWidget || window.KWidget) && true,
-      w3DS: window.w3ds && true,
-      React: window.React,
-      Angular: window.angular,
-      jQuery: window.jQuery || window.$,
-      Dojo: window.dojo,
-      Bootstrap: window.bootstrap,
-      Vue: window.Vue,
-    };
-
-    const pageInfo = {
-      digitalData: window.digitalData,
-      libraries
-    };
-
-    if (libraries.jQuery) { // try to get version number
-      try {
-        // let's try to see if there are more than one version lurking in the shadows
-        const versions = [];
-        Object.keys(window).forEach(key => {
-          if (key.indexOf('jQuery') === 0 || key.indexOf('$') === 0) {
-            if (typeof window[key] === 'function') {
-              const version = window[key]().jquery;
-              if (version) {
-                versions.push(version);
-              }
-            }
-          }
-        });
-
-        libraries.jQuery = versions.length ? versions : true;
-      } catch (e) {
-        libraries.jQuery = libraries.jQuery().jquery || true;
-      }
-    }
-
-    if (libraries.Dojo) { // try to get version number
-      libraries.Dojo = (libraries.Dojo.version && libraries.Dojo.version.toString()) || true;
-    }
-
-    if (libraries.Bootstrap) { // try to get version number
-      libraries.Bootstrap = (libraries.Bootstrap.Alert && libraries.Bootstrap.Alert.VERSION) || true;
-    }
-
-    if (libraries.Vue) { // try to get version number
-      libraries.Vue = (libraries.Vue && libraries.Vue.version) || true;
-    }
-
-    if (libraries.React) { // try to get version number
-      libraries.React = libraries.React.version || true;
-    } else {
-      libraries.React = findReactRoot();
-    }
-
-    if (libraries.Angular) {
-      libraries.Angular = (window.angular.version && window.angular.version.full) || true;
-    } else {
-      const angularRoot = window.getAllAngularRootElements && window.getAllAngularRootElements();
-
-      if (angularRoot) {
-        if (angularRoot.length) {
-          libraries.Angular = angularRoot[0].getAttribute('ng-version') || true;
-        } else {
-          libraries.Angular= true;
-        }
-      }
-    }
-
-    if (libraries["IBM Analytics"]) {
-      const analytics = libraries["IBM Analytics"];
-      if (analytics.ver) {
-        libraries["IBM Analytics"] = analytics.ver.libraryVersion || true;
-      } else {
-        libraries["IBM Analytics"] = true;
-      }
-    }
-
-    document.body.dataset.pageInfo = JSON.stringify(pageInfo);
-  }
-
-  function findReactRoot (elem) {
-    elem = elem || document.querySelector('body');
-    const children = elem.children;
-    let result;
-
-    for (let i = 0; i < children.length; i++) {
-      if (children[i]._reactRootContainer) {
-        result = true;
-        break;
-      } else {
-        findReactRoot(children[i]);
-      }
-    }
-
-    return result;
-  }
-
-  document.querySelector('#${scriptId}').remove();
-`,
-  scriptId
-);
-
-sendValidation();
+injectScript();
 
 function sendValidation() {
   const carbonComponents = document.querySelector(prefixSelectors);
@@ -172,7 +61,7 @@ function sendValidation() {
     // inject css via this method for development purposes
     if (process.env.NODE_ENV === 'development' && !msg.carbonDevtoolsInjected) {
       if (msg.ignoreValidation || msg.runningCarbon) {
-        const cssURL = chrome.extension.getURL('/inject/index.css');
+        const cssURL = chrome.runtime.getURL('/inject/index.css');
 
         if (!document.querySelector(`[href="${cssURL}"]`)) {
           injectStyles(cssURL);
@@ -227,10 +116,14 @@ function injectStyles(url) {
   document.head.appendChild(elem);
 }
 
-function injectScript(content, id) {
-  var script = document.createElement('script');
-  script.setAttribute('type', 'text/javascript');
-  script.setAttribute('id', id);
-  script.innerHTML = content;
-  document.body.appendChild(script);
+function injectScript() {
+  const s = document.createElement('script');
+  s.src = chrome.runtime.getURL('/validate/validationScript.js');
+  s.onload = function () {
+    this.remove();
+
+    // Insert pageInfo by loaded script then sendValidation
+    sendValidation();
+  };
+  (document.head || document.documentElement).appendChild(s);
 }

--- a/packages/web-extension/src/validate/validationScript.js
+++ b/packages/web-extension/src/validate/validationScript.js
@@ -1,0 +1,113 @@
+bxDevGetLibraries();
+
+function bxDevGetLibraries() {
+  const libraries = {
+    'IBM Analytics':
+      window._ibmAnalytics ||
+      document.querySelector('script[src*="common/stats/ibm-common.js"]') ||
+      undefined,
+    Kaltura: (window.kWidget || window.KWidget) && true,
+    w3DS: window.w3ds && true,
+    React: window.React,
+    Angular: window.angular,
+    jQuery: window.jQuery || window.$,
+    Dojo: window.dojo,
+    Bootstrap: window.bootstrap,
+    Vue: window.Vue,
+  };
+
+  const pageInfo = {
+    digitalData: window.digitalData,
+    libraries,
+  };
+
+  if (libraries.jQuery) {
+    // try to get version number
+    try {
+      // let's try to see if there are more than one version lurking in the shadows
+      const versions = [];
+      Object.keys(window).forEach((key) => {
+        if (key.indexOf('jQuery') === 0 || key.indexOf('$') === 0) {
+          if (typeof window[key] === 'function') {
+            const version = window[key]().jquery;
+            if (version) {
+              versions.push(version);
+            }
+          }
+        }
+      });
+
+      libraries.jQuery = versions.length ? versions : true;
+    } catch (e) {
+      libraries.jQuery = libraries.jQuery().jquery || true;
+    }
+  }
+
+  if (libraries.Dojo) {
+    // try to get version number
+    libraries.Dojo =
+      (libraries.Dojo.version && libraries.Dojo.version.toString()) || true;
+  }
+
+  if (libraries.Bootstrap) {
+    // try to get version number
+    libraries.Bootstrap =
+      (libraries.Bootstrap.Alert && libraries.Bootstrap.Alert.VERSION) || true;
+  }
+
+  if (libraries.Vue) {
+    // try to get version number
+    libraries.Vue = (libraries.Vue && libraries.Vue.version) || true;
+  }
+
+  if (libraries.React) {
+    // try to get version number
+    libraries.React = libraries.React.version || true;
+  } else {
+    libraries.React = findReactRoot();
+  }
+
+  if (libraries.Angular) {
+    libraries.Angular =
+      (window.angular.version && window.angular.version.full) || true;
+  } else {
+    const angularRoot =
+      window.getAllAngularRootElements && window.getAllAngularRootElements();
+
+    if (angularRoot) {
+      if (angularRoot.length) {
+        libraries.Angular = angularRoot[0].getAttribute('ng-version') || true;
+      } else {
+        libraries.Angular = true;
+      }
+    }
+  }
+
+  if (libraries['IBM Analytics']) {
+    const analytics = libraries['IBM Analytics'];
+    if (analytics.ver) {
+      libraries['IBM Analytics'] = analytics.ver.libraryVersion || true;
+    } else {
+      libraries['IBM Analytics'] = true;
+    }
+  }
+
+  document.body.dataset.pageInfo = JSON.stringify(pageInfo);
+}
+
+function findReactRoot(elem) {
+  elem = elem || document.querySelector('body');
+  const children = elem.children;
+  let result;
+
+  for (let i = 0; i < children.length; i++) {
+    if (children[i]._reactRootContainer) {
+      result = true;
+      break;
+    } else {
+      findReactRoot(children[i]);
+    }
+  }
+
+  return result;
+}

--- a/packages/web-extension/webpack.common.js
+++ b/packages/web-extension/webpack.common.js
@@ -127,6 +127,10 @@ module.exports = {
             return syncManifestPackage(content.toString());
           },
         },
+        {
+          from: './src/validate/validationScript.js',
+          to: './validate',
+        },
       ],
     }),
     new Visualizer(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -11275,13 +11275,6 @@ node-fetch@^2.5.0, node-fetch@^2.6.7:
   dependencies:
     whatwg-url "^5.0.0"
 
-node-fetch@^2.6.1:
-  version "2.6.6"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.6.tgz#1751a7c01834e8e1697758732e9efb6eeadfaf89"
-  integrity sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==
-  dependencies:
-    whatwg-url "^5.0.0"
-
 node-fetch@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.1.1.tgz#d0d9607e455b3087e3092b821b5b1f1ebf4c2147"


### PR DESCRIPTION
Closes #84 

Add support for Manifest v3

##### New

- Add new package for Manifest v2 (FIrefox issue)

##### Changed

- Update functions in `utilities` package to support v3
- Update main package to support v3

#### Testing / Reviewing

- Navigate to `web-extenstion` (Manifest v3) or `web-extension-v2` (Manifest v2) package and run `yarn watch` or `yarn build`.
- Setup Chrome (v3) / Firefox (v2) browser with custom extension. 
- Open any website built using Carbon.
- Verify Devtools functionality.
