### PR TITLE
chore(web-extension): specify dependencies to ensure build order

### DIFF
--- a/packages/web-extension-v2/package.json
+++ b/packages/web-extension-v2/package.json
@@ -30,15 +30,16 @@
     "@carbon/type": "^10.33.0",
     "carbon-components": "^10.41.0",
     "carbon-components-react": "^7.41.0",
+    "carbon-devtools": "^2.7.7",
     "color": "^3.1.2",
     "node-fetch": "^3.1.1",
     "url": "^0.11.0"
   },
   "devDependencies": {
-    "@carbon/icons-react": "^10.37.0",
     "@babel/core": "^7.11.6",
     "@babel/preset-env": "^7.11.5",
     "@babel/preset-react": "^7.10.4",
+    "@carbon/icons-react": "^10.37.0",
     "babel-loader": "^8.1.0",
     "clean-webpack-plugin": "^4.0.0",
     "copy-webpack-plugin": "^6.2.1",

--- a/packages/web-extension/package.json
+++ b/packages/web-extension/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@carbon/colors": "^10.30.0",
+    "@carbon/devtools-component-list": "^2.7.7",
     "@carbon/grid": "^10.33.0",
     "@carbon/ibm-products": "^1.2.4",
     "@carbon/ibm-security": "^1.31.0",
@@ -35,10 +36,10 @@
     "url": "^0.11.0"
   },
   "devDependencies": {
-    "@carbon/icons-react": "^10.37.0",
     "@babel/core": "^7.11.6",
     "@babel/preset-env": "^7.11.5",
     "@babel/preset-react": "^7.10.4",
+    "@carbon/icons-react": "^10.37.0",
     "babel-loader": "^8.1.0",
     "clean-webpack-plugin": "^4.0.0",
     "copy-webpack-plugin": "^6.2.1",


### PR DESCRIPTION
Attempt to fix the broken build by explicitly specifying dependencies, which will force lerna to run build in a certain order such that the reuquired artifats are present.

#### Changelog

##### New

- web-extension: Specifies dependency on `@carbon/devtools-component-list`
- web-extension-v2: Specifies dependency on `carbon-devtools`

#### Testing / Reviewing

Build runs clean.
