### PR TITLE
chore(version): update version number & publisher info

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,14 +25,14 @@
     "node": ">=12.x"
   },
   "license": "Apache-2.0",
-  "author": "James Dow",
+  "author": "IBM",
   "repository": {
     "type": "git",
     "url": "https://github.com/carbon-design-system/devtools"
   },
   "bugs": {
     "url": "https://github.com/carbon-design-system/devtools/issues/new",
-    "email": "james.dow@us.ibm.com"
+    "email": "carbon@us.ibm.com"
   },
   "homepage": "https://github.com/carbon-design-system/devtools#readme",
   "workspaces": {

--- a/packages/component-list/package.json
+++ b/packages/component-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carbon/devtools-component-list",
-  "version": "2.7.7",
+  "version": "2.7.8",
   "description": "Generates a list of components and their selectors across all of the Carbon libraries.",
   "main": "./dist/index.json",
   "scripts": {
@@ -74,7 +74,7 @@
     "Tools",
     "Development"
   ],
-  "author": "James Dow",
+  "author": "IBM",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -82,7 +82,7 @@
   },
   "bugs": {
     "url": "https://github.com/carbon-design-system/devtools/issues/new",
-    "email": "james.dow@us.ibm.com"
+    "email": "carbon@us.ibm.com"
   },
   "homepage": "https://github.com/carbon-design-system/devtools#readme"
 }

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carbon/devtools-utilities",
-  "version": "2.7.7",
+  "version": "2.7.8",
   "description": "Common utilities and functions used across throughout Carbon Devtools.",
   "main": "index.js",
   "scripts": {
@@ -21,14 +21,14 @@
     "Functions"
   ],
   "license": "Apache-2.0",
-  "author": "James Dow",
+  "author": "IBM",
   "repository": {
     "type": "git",
     "url": "https://github.com/carbon-design-system/devtools"
   },
   "bugs": {
     "url": "https://github.com/carbon-design-system/devtools/issues/new",
-    "email": "james.dow@us.ibm.com"
+    "email": "carbon@us.ibm.com"
   },
   "homepage": "https://github.com/carbon-design-system/devtools#readme",
   "dependencies": {

--- a/packages/web-extension/package.json
+++ b/packages/web-extension/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "carbon-devtools",
-  "version": "2.7.7",
+  "name": "carbon-devtools-v10",
+  "version": "2.7.8",
   "private": true,
   "description": "A basic set of tools for teams building live Carbon pages.",
   "main": "dist/manifest.json",
@@ -91,7 +91,7 @@
     "Tools",
     "Development"
   ],
-  "author": "James Dow",
+  "author": "IBM",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -99,7 +99,7 @@
   },
   "bugs": {
     "url": "https://github.com/carbon-design-system/devtools/issues/new",
-    "email": "james.dow@us.ibm.com"
+    "email": "carbon@us.ibm.com"
   },
   "homepage": "https://github.com/carbon-design-system/devtools#readme",
   "eslintConfig": {

--- a/packages/web-extension/package.json
+++ b/packages/web-extension/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "carbon-devtools-v10",
+  "name": "carbon-devtools-(v10)",
   "version": "2.7.8",
   "private": true,
   "description": "A basic set of tools for teams building live Carbon pages.",


### PR DESCRIPTION
Mimics 9ea9d66 to trigger new publish & updates publisher information to remove @photodow

Worth noting that this package hasn't been updated since Jan 19, 2022 - I'm not sure what kinds of gremlins we may run into with this release, but the chrome dashboard has a "rollback" button.

#### Changelog

##### Changed

- changes package name to `carbon-devtools-v10`
- changes publisher to `IBM`
- changes email address to `carbon@us.ibm.com`