### PR TITLE
chore(version-bump): update to 2.8.3

### DIFF
--- a/packages/component-list/package.json
+++ b/packages/component-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carbon/devtools-component-list",
-  "version": "2.7.8",
+  "version": "2.8.3",
   "description": "Generates a list of components and their selectors across all of the Carbon libraries.",
   "main": "./dist/index.json",
   "scripts": {

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carbon/devtools-utilities",
-  "version": "2.7.8",
+  "version": "2.8.3",
   "description": "Common utilities and functions used across throughout Carbon Devtools.",
   "main": "index.js",
   "scripts": {

--- a/packages/web-extension/package.json
+++ b/packages/web-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon-devtools-(v10)",
-  "version": "2.7.8",
+  "version": "2.8.3",
   "private": true,
   "description": "A basic set of tools for teams building live Carbon pages.",
   "main": "dist/manifest.json",


### PR DESCRIPTION
Followup to #322 - this gets package.json files back in alignment with our [releases](https://github.com/carbon-design-system/devtools/releases)

#### Changelog

##### Changed

- updates version number