### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,4 +1,6 @@
 name: PR Check
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/carbon-design-system/devtools/security/code-scanning/2](https://github.com/carbon-design-system/devtools/security/code-scanning/2)

To fix the problem, we need to explicitly set the `permissions` for the workflow or the job. Since this workflow doesn't push code, modify pull requests, or use any actions that require write access, we can safely add `permissions: contents: read` to the top level of the workflow file (just under the workflow name and before `on:`), which will apply to all jobs in the workflow. No additional steps, imports, or packages are needed. Edit the `.github/workflows/pr-check.yml` file to insert the `permissions` key directly after the workflow name and before the `on:` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
