### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,6 @@
 name: Publish web-extension
+permissions:
+  contents: read
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/carbon-design-system/devtools/security/code-scanning/1](https://github.com/carbon-design-system/devtools/security/code-scanning/1)

To fix the problem, you should add a `permissions` block at the top level of the workflow (to apply to all jobs by default) or specifically to any job that requires a different set of permissions. In this specific example, the publish workflow does not need write access to repository contents, so we can assign the minimal required permissions, starting with `contents: read`. This is done by inserting:

```yaml
permissions:
  contents: read
```

immediately after the `name` declaration and before the `on:` block. If in the future certain steps require more privileges (such as writing issues or PRs), those could be added with the least privilege required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
