### PR TITLE
Potential fix for code scanning alert no. 3: DOM text reinterpreted as HTML

### DIFF
--- a/packages/web-extension/src/inject/components/Specs/Color/index.js
+++ b/packages/web-extension/src/inject/components/Specs/Color/index.js
@@ -18,6 +18,15 @@ import Color from 'color';
 
 const { prefix } = settings;
 
+function escapeHTML(str) {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 function highlightSpecsColor(target) {
   if (target) {
     const styles = window.getComputedStyle(target);
@@ -62,7 +71,7 @@ function highlightSpecsColor(target) {
       updateTooltipContent(
         __specsContainer(tooltipGroups).replace(
           /<!--componentnameplaceholder-->/g,
-          getComponentName(target)
+          escapeHTML(getComponentName(target))
         )
       );
       addHighlight(target, { type: 'specs' });


### PR DESCRIPTION
Potential fix for [https://github.com/carbon-design-system/devtools/security/code-scanning/3](https://github.com/carbon-design-system/devtools/security/code-scanning/3)

The best way to fix the problem is to contextually escape or sanitize the value interpolated into `.innerHTML`, so that untrusted data cannot introduce HTML or JavaScript. In this codebase, the vulnerable flow is through a placeholder, replaced with an untrusted value. We should escape any meta-characters in the string returned from `getComponentName` before passing it to `.replace(...)`. This can be done by introducing a utility function like `escapeHTML(str)` that replaces `&`, `<`, `>`, `"`, `'` with HTML entities. The most straightforward and safe fix is to implement this helper (in Color/index.js, as shown), then ensure that everywhere the component name is substituted into HTML, it is via this escaping.

Thus, the following changes are needed:
- In packages/web-extension/src/inject/components/Specs/Color/index.js, add a helper called escapeHTML.
- In highlightSpecsColor(), change the call to `.replace(/<!--componentnameplaceholder-->/g, getComponentName(target))` so the second argument is `escapeHTML(getComponentName(target))`.

No changes are needed in Tooltip/index.js (as innerHTML will be set to already-escaped HTML by Color/index.js), nor in getComponentName.js (as component name can remain raw).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
